### PR TITLE
[#57] Update android deployment workflow flutter version

### DIFF
--- a/.github/workflows/android_deploy_firebase.yml
+++ b/.github/workflows/android_deploy_firebase.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'hotfix/**'
 
 jobs:
   build_and_deploy_android:
@@ -24,7 +25,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: '3.3.10'
+          flutter-version: '3.7.9'
 
       - name: Get flutter dependencies
         run: flutter pub get

--- a/.github/workflows/android_deploy_firebase.yml
+++ b/.github/workflows/android_deploy_firebase.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'hotfix/**'
 
 jobs:
   build_and_deploy_android:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.1.0+1
+version: 0.2.1+1
 
 environment:
   sdk: ">=2.17.5 <3.0.0"


### PR DESCRIPTION
- Closes https://github.com/nimblehq/flutter-ic-lydia-ryan/issues/57

## What happened 👀

- Updated flutter version on android deployment workflow
- bumped app version to 2.1.0

## Insight 📝

We updated the Android deployment version in `test.yml` but forgot to update it in `android_deploy_firebase.yml` too 🙈 

## Proof Of Work 📹

![Screenshot 2566-04-07 at 17 54 37](https://user-images.githubusercontent.com/53168251/230597202-c4c92e88-aac2-4b60-a8b4-18bcf527f924.png)

