### PR TITLE
[#62] Fix: Login JSON response cannot be parsed 

### DIFF
--- a/lib/model/response/login_response.dart
+++ b/lib/model/response/login_response.dart
@@ -5,14 +5,19 @@ part 'login_response.g.dart';
 
 @JsonSerializable()
 class LoginResponse {
-  final String grantType;
-  final String email;
-  final String password;
-  final String clientId;
-  final String clientSecret;
+  final String accessToken;
+  final String tokenType;
+  final int expiresIn;
+  final String refreshToken;
+  final int createdAt;
 
-  LoginResponse(this.grantType, this.email, this.password, this.clientId,
-      this.clientSecret);
+  LoginResponse(
+    this.accessToken,
+    this.tokenType,
+    this.expiresIn,
+    this.refreshToken,
+    this.createdAt,
+  );
 
   factory LoginResponse.fromJson(Map<String, dynamic> json) =>
       _$LoginResponseFromJson(mapDataJson(json));

--- a/test/api/repository/auth_repository_test.dart
+++ b/test/api/repository/auth_repository_test.dart
@@ -26,7 +26,7 @@ void main() {
     });
 
     test('When calling login successfully, it returns LoginResponse', () async {
-      final loginResponse = LoginResponse("", "", "", "", "");
+      final loginResponse = LoginResponse("", "", 0, "", 0);
 
       when(mockAuthService.login(any)).thenAnswer((_) async => loginResponse);
 

--- a/test/usecases/login_use_case_test.dart
+++ b/test/usecases/login_use_case_test.dart
@@ -20,7 +20,7 @@ void main() {
     });
 
     test('When login is successful, it returns Success result', () async {
-      final loginResponse = LoginResponse("", "", "", "", "");
+      final loginResponse = LoginResponse("", "", 0, "", 0);
       when(mockAuthRepository.login(email, password))
           .thenAnswer((_) async => loginResponse);
 


### PR DESCRIPTION
- Closes https://github.com/nimblehq/flutter-ic-lydia-ryan/issues/62

## What happened 👀

`LoginResponse` had the wrong data format, it was a duplicate of `LoginRequest` 🙈 

## Insight 📝

N/A

## Proof Of Work 📹

<img width="1190" alt="Screenshot 2566-04-12 at 17 15 06" src="https://user-images.githubusercontent.com/53168251/231428387-abfc8339-d7d9-444a-a759-62739526e817.png">

