### PR TITLE
[#43][Part2][Integrate] Automatically signing in when API returns 401

### DIFF
--- a/lib/di/interceptor/app_interceptor.dart
+++ b/lib/di/interceptor/app_interceptor.dart
@@ -24,7 +24,8 @@ class AppInterceptor extends Interceptor {
   Future onRequest(
       RequestOptions options, RequestInterceptorHandler handler) async {
     if (_requireAuthenticate) {
-      options.headers.putIfAbsent(_headerAuthorization, () => "");
+      options.headers.putIfAbsent(_headerAuthorization,
+          () => _sharedPreferencesUtils.headerAuthorization);
     }
     return super.onRequest(options, handler);
   }
@@ -51,8 +52,7 @@ class AppInterceptor extends Interceptor {
       final result = await refreshTokenUseCase.call();
       if (result is Success<LoginResponse>) {
         // Update new token header
-        final newAuthToken =
-            result.value.tokenType + _sharedPreferencesUtils.accessToken;
+        final newAuthToken = _sharedPreferencesUtils.headerAuthorization;
         error.requestOptions.headers[_headerAuthorization] = newAuthToken;
 
         // Create request with new access token

--- a/lib/di/interceptor/app_interceptor.dart
+++ b/lib/di/interceptor/app_interceptor.dart
@@ -1,23 +1,30 @@
 import 'dart:io';
 
 import 'package:dio/dio.dart';
+import 'package:lydiaryanfluttersurvey/di/injection.dart';
+import 'package:lydiaryanfluttersurvey/model/response/login_response.dart';
+import 'package:lydiaryanfluttersurvey/storage/shared_preferences_utils.dart';
+import 'package:lydiaryanfluttersurvey/usecases/base/base_use_case.dart';
+import 'package:lydiaryanfluttersurvey/usecases/refresh_token_use_case.dart';
+
+const _headerAuthorization = 'Authorization';
 
 class AppInterceptor extends Interceptor {
   final bool _requireAuthenticate;
   final Dio _dio;
+  final SharedPreferencesUtils _sharedPreferencesUtils;
 
   AppInterceptor(
     this._requireAuthenticate,
     this._dio,
+    this._sharedPreferencesUtils,
   );
 
   @override
   Future onRequest(
       RequestOptions options, RequestInterceptorHandler handler) async {
     if (_requireAuthenticate) {
-      // TODO header authorization here
-      // options.headers
-      //     .putIfAbsent(HEADER_AUTHORIZATION, () => "");
+      options.headers.putIfAbsent(_headerAuthorization, () => "");
     }
     return super.onRequest(options, handler);
   }
@@ -35,34 +42,37 @@ class AppInterceptor extends Interceptor {
   }
 
   Future<void> _doRefreshToken(
-    DioError err,
+    DioError error,
     ErrorInterceptorHandler handler,
   ) async {
     try {
-      // TODO Request new token
+      final RefreshTokenUseCase refreshTokenUseCase =
+          getIt<RefreshTokenUseCase>();
+      final result = await refreshTokenUseCase.call();
+      if (result is Success<LoginResponse>) {
+        // Update new token header
+        final newAuthToken =
+            result.value.tokenType + _sharedPreferencesUtils.accessToken;
+        error.requestOptions.headers[_headerAuthorization] = newAuthToken;
 
-      // if (result is Success) {
-      // TODO Update new token header
-      // err.requestOptions.headers[_headerAuthorization] = newToken;
-
-      // Create request with new access token
-      final options = Options(
-          method: err.requestOptions.method,
-          headers: err.requestOptions.headers);
-      final newRequest = await _dio.request(
-          "${err.requestOptions.baseUrl}${err.requestOptions.path}",
-          options: options,
-          data: err.requestOptions.data,
-          queryParameters: err.requestOptions.queryParameters);
-      handler.resolve(newRequest);
-      //  } else {
-      //    handler.next(err);
-      //  }
+        // Create request with new access token
+        final options = Options(
+            method: error.requestOptions.method,
+            headers: error.requestOptions.headers);
+        final newRequest = await _dio.request(
+            "${error.requestOptions.baseUrl}${error.requestOptions.path}",
+            options: options,
+            data: error.requestOptions.data,
+            queryParameters: error.requestOptions.queryParameters);
+        handler.resolve(newRequest);
+      } else {
+        handler.next(error);
+      }
     } catch (exception) {
       if (exception is DioError) {
         handler.next(exception);
       } else {
-        handler.next(err);
+        handler.next(error);
       }
     }
   }

--- a/lib/di/provider/dio_provider.dart
+++ b/lib/di/provider/dio_provider.dart
@@ -1,8 +1,10 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
+import 'package:lydiaryanfluttersurvey/di/injection.dart';
 import 'package:lydiaryanfluttersurvey/di/interceptor/app_interceptor.dart';
 import 'package:lydiaryanfluttersurvey/env.dart';
+import 'package:lydiaryanfluttersurvey/storage/shared_preferences_utils.dart';
 
 const String headerContentType = 'Content-Type';
 const String defaultContentType = 'application/json; charset=utf-8';
@@ -18,9 +20,12 @@ class DioProvider {
 
   Dio _createDio({bool requireAuthenticate = false}) {
     final dio = Dio();
+    final SharedPreferencesUtils sharedPreferencesUtils =
+        getIt<SharedPreferencesUtils>();
     final appInterceptor = AppInterceptor(
       requireAuthenticate,
       dio,
+      sharedPreferencesUtils,
     );
     final interceptors = <Interceptor>[];
     interceptors.add(appInterceptor);

--- a/lib/screens/login/login_screen.dart
+++ b/lib/screens/login/login_screen.dart
@@ -11,6 +11,7 @@ import 'package:lydiaryanfluttersurvey/resources/dimensions.dart';
 import 'package:lydiaryanfluttersurvey/screens/widgets/app_input_widget.dart';
 import 'package:lydiaryanfluttersurvey/screens/widgets/circle_loading_indicator.dart';
 import 'package:lydiaryanfluttersurvey/screens/widgets/rounded_rectangle_button_widget.dart';
+import 'package:lydiaryanfluttersurvey/storage/shared_preferences_utils.dart';
 import 'package:lydiaryanfluttersurvey/usecases/login_use_case.dart';
 import 'package:lydiaryanfluttersurvey/usecases/verify_logged_in_use_case.dart';
 import 'package:lydiaryanfluttersurvey/utils/toast_message.dart';

--- a/lib/screens/login/login_screen.dart
+++ b/lib/screens/login/login_screen.dart
@@ -11,7 +11,6 @@ import 'package:lydiaryanfluttersurvey/resources/dimensions.dart';
 import 'package:lydiaryanfluttersurvey/screens/widgets/app_input_widget.dart';
 import 'package:lydiaryanfluttersurvey/screens/widgets/circle_loading_indicator.dart';
 import 'package:lydiaryanfluttersurvey/screens/widgets/rounded_rectangle_button_widget.dart';
-import 'package:lydiaryanfluttersurvey/storage/shared_preferences_utils.dart';
 import 'package:lydiaryanfluttersurvey/usecases/login_use_case.dart';
 import 'package:lydiaryanfluttersurvey/usecases/verify_logged_in_use_case.dart';
 import 'package:lydiaryanfluttersurvey/utils/toast_message.dart';

--- a/lib/storage/shared_preferences_utils.dart
+++ b/lib/storage/shared_preferences_utils.dart
@@ -6,9 +6,15 @@ abstract class SharedPreferencesUtils {
 
   String get accessToken;
 
+  String get tokenType;
+
+  String get headerAuthorization;
+
   void setRefreshToken(String? value);
 
   void setAccessToken(String? value);
+
+  void setTokenType(String? tokenType);
 }
 
 @Singleton(as: SharedPreferencesUtils)
@@ -25,6 +31,12 @@ class SharedPreferencesUtilsImpl implements SharedPreferencesUtils {
       _sharedPreferences.getString('refresh_token') ?? '';
 
   @override
+  String get tokenType => _sharedPreferences.getString('token_type') ?? '';
+
+  @override
+  String get headerAuthorization => '$tokenType $accessToken';
+
+  @override
   void setRefreshToken(String? value) async {
     await _sharedPreferences.setString('refresh_token', value ?? '');
   }
@@ -32,5 +44,10 @@ class SharedPreferencesUtilsImpl implements SharedPreferencesUtils {
   @override
   void setAccessToken(String? value) async {
     await _sharedPreferences.setString('access_token', value ?? '');
+  }
+
+  @override
+  void setTokenType(String? tokenType) async {
+    await _sharedPreferences.setString('token_type', tokenType ?? '');
   }
 }

--- a/lib/usecases/login_use_case.dart
+++ b/lib/usecases/login_use_case.dart
@@ -17,9 +17,9 @@ class LoginInput {
 @Injectable()
 class LoginUseCase extends UseCase<LoginResponse, LoginInput> {
   final AuthRepository _authRepository;
-  final SharedPreferencesUtils _sharedPreferencesUtils;
+  final SharedPreferencesUtils _sharedPreferenceUtils;
 
-  LoginUseCase(this._authRepository, this._sharedPreferencesUtils);
+  LoginUseCase(this._authRepository, this._sharedPreferenceUtils);
 
   @override
   Future<Result<LoginResponse>> call(LoginInput params) {
@@ -32,7 +32,7 @@ class LoginUseCase extends UseCase<LoginResponse, LoginInput> {
   }
 
   void _saveToken(LoginResponse loginResponse) {
-    _sharedPreferencesUtils.setAccessToken(loginResponse.accessToken);
-    _sharedPreferencesUtils.setRefreshToken(loginResponse.refreshToken);
+    _sharedPreferenceUtils.setAccessToken(loginResponse.accessToken);
+    _sharedPreferenceUtils.setRefreshToken(loginResponse.refreshToken);
   }
 }

--- a/lib/usecases/login_use_case.dart
+++ b/lib/usecases/login_use_case.dart
@@ -34,5 +34,6 @@ class LoginUseCase extends UseCase<LoginResponse, LoginInput> {
   void _saveToken(LoginResponse loginResponse) {
     _sharedPreferenceUtils.setAccessToken(loginResponse.accessToken);
     _sharedPreferenceUtils.setRefreshToken(loginResponse.refreshToken);
+    _sharedPreferenceUtils.setTokenType(loginResponse.tokenType);
   }
 }

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -13,8 +13,8 @@ import 'package:mockito/annotations.dart';
   MockSpec<AuthRepository>(),
   MockSpec<AuthService>(),
   MockSpec<DioError>(),
-  MockSpec<UseCaseException>(),
   MockSpec<SharedPreferencesUtils>(),
+  MockSpec<UseCaseException>(),
   MockSpec<LoginUseCase>(),
   MockSpec<VerifyLoggedInUseCase>(),
 ])

--- a/test/usecases/login_use_case_test.dart
+++ b/test/usecases/login_use_case_test.dart
@@ -67,6 +67,21 @@ void main() {
           .setRefreshToken(loginResponse.refreshToken));
     });
 
+    test('When login is successful, it saves tokenType to shared preferences',
+        () async {
+      final loginResponse = LoginResponse("", "tokenType", 0, "", 0);
+      when(mockAuthRepository.login(email, password))
+          .thenAnswer((_) async => loginResponse);
+
+      final result = await useCase.call(LoginInput(
+        email: email,
+        password: password,
+      ));
+
+      expect(result, isA<Success<LoginResponse>>());
+      verify(mockSharedPreferencesUtils.setTokenType(loginResponse.tokenType));
+    });
+
     test('When login is unsuccessful, it returns Failed result', () async {
       when(mockAuthRepository.login(email, password))
           .thenAnswer((_) => Future.error(UseCaseException(Exception(''))));


### PR DESCRIPTION
- Closes #43 

## What happened 👀

- Implemented network interceptor to call refresh token when API returns `401` error code.

## Insight 📝

- Updated saving `tokenType` and getter for `AuthorizationHeader` in SharedPreferencesUtils to use for request header in the Interceptor.

## Proof Of Work 📹

N/A since for now, we cannot mock the 401 😢 . Will create a bug ticket once we found an issue.
