### PR TITLE
[#35] [#36] [UI] [Integrate] As a user, I can see the text field question when taking a survey

### DIFF
--- a/lib/screens/surveydetails/survey_detail_screen.dart
+++ b/lib/screens/surveydetails/survey_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:lydiaryanfluttersurvey/di/injection.dart';
 import 'package:lydiaryanfluttersurvey/model/ui/survey_detail_ui_model.dart';
 import 'package:lydiaryanfluttersurvey/screens/surveydetails/survey_detail_view_model.dart';
 import 'package:lydiaryanfluttersurvey/screens/surveydetails/widget/question_paging_widget.dart';
+import 'package:lydiaryanfluttersurvey/screens/widgets/background_widget.dart';
 import 'package:lydiaryanfluttersurvey/usecases/get_survey_detail_use_case.dart';
 
 import 'survey_detail_state.dart';
@@ -58,10 +59,16 @@ class _SurveyDetailScreenState extends ConsumerState<SurveyDetailScreen> {
       Fluttertoast.showToast(msg: errorMessage);
     }
 
-    return surveyDetail != null
-        ? Scaffold(
-            body: QuestionPagingWidget(surveyDetailUiModel: surveyDetail),
-          )
-        : const SizedBox.shrink();
+    if (surveyDetail == null) {
+      return const SizedBox.shrink();
+    }
+
+    return BackgroundWidget(
+      image: Image.network(surveyDetail.largeCoverImageUrl).image,
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: QuestionPagingWidget(surveyDetailUiModel: surveyDetail),
+      ),
+    );
   }
 }

--- a/lib/screens/surveydetails/widget/answer_text_field_widget.dart
+++ b/lib/screens/surveydetails/widget/answer_text_field_widget.dart
@@ -39,11 +39,6 @@ class _AnswerTextFieldWidgetState extends State<AnswerTextFieldWidget> {
 
   @override
   Widget build(BuildContext context) {
-    TextField(
-      onChanged: (text) => _onTextChanged(-1, text),
-      controller: TextEditingController(),
-    );
-
     return Center(
       child: Form(
         autovalidateMode: AutovalidateMode.always,

--- a/lib/screens/surveydetails/widget/answer_text_field_widget.dart
+++ b/lib/screens/surveydetails/widget/answer_text_field_widget.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:lydiaryanfluttersurvey/model/ui/question_ui_model.dart';
+import 'package:lydiaryanfluttersurvey/resources/dimensions.dart';
+import 'package:lydiaryanfluttersurvey/screens/widgets/app_input_widget.dart';
+
+class AnswerTextFieldWidget extends StatefulWidget {
+  final QuestionUiModel question;
+  final Function(List<String>) onAnswered;
+
+  const AnswerTextFieldWidget({
+    Key? key,
+    required this.question,
+    required this.onAnswered,
+  }) : super(key: key);
+
+  @override
+  State<AnswerTextFieldWidget> createState() => _AnswerTextFieldWidgetState();
+}
+
+class _AnswerTextFieldWidgetState extends State<AnswerTextFieldWidget> {
+  final List<String> _answers = [];
+  final List<TextEditingController> _controllers = [];
+
+  void _onTextChanged(
+    int index,
+    String text,
+  ) {
+    _answers[index] = text;
+    widget.onAnswered(_answers);
+  }
+
+  @override
+  void dispose() {
+    for (var element in _controllers) {
+      element.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    TextField(
+      onChanged: (text) => _onTextChanged(-1, text),
+      controller: TextEditingController(),
+    );
+
+    return Center(
+      child: Form(
+        autovalidateMode: AutovalidateMode.always,
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            ...List<Widget>.generate(
+              widget.question.answers.length,
+              (index) {
+                final controller = TextEditingController();
+                controller.addListener(() {
+                  _onTextChanged(index, controller.text);
+                });
+                _controllers.add(controller);
+                return Padding(
+                  padding: const EdgeInsets.only(
+                    bottom: Dimensions.paddingSmallPlus,
+                  ),
+                  child: AppInputWidget(
+                    controller: controller,
+                    hintText: widget.question.answers[index].text ?? "",
+                    textInputAction:
+                        (index == widget.question.answers.length - 1)
+                            ? TextInputAction.done
+                            : TextInputAction.next,
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/surveydetails/widget/question_paging_widget.dart
+++ b/lib/screens/surveydetails/widget/question_paging_widget.dart
@@ -9,7 +9,7 @@ import 'package:lydiaryanfluttersurvey/model/ui/survey_detail_ui_model.dart';
 import 'package:lydiaryanfluttersurvey/resources/dimensions.dart';
 import 'package:lydiaryanfluttersurvey/screens/surveydetails/widget/answer_rating_widget.dart';
 import 'package:lydiaryanfluttersurvey/screens/surveydetails/widget/answer_smiley_widget.dart';
-import 'package:lydiaryanfluttersurvey/screens/widgets/background_widget.dart';
+import 'package:lydiaryanfluttersurvey/screens/surveydetails/widget/answer_text_field_widget.dart';
 import 'package:lydiaryanfluttersurvey/screens/widgets/rounded_rectangle_button_widget.dart';
 
 class QuestionPagingWidget extends StatefulWidget {
@@ -37,33 +37,25 @@ class _QuestionPagingWidgetState extends State<QuestionPagingWidget> {
     }
     final PageController pageController = PageController();
 
-    return Stack(
-      children: [
-        BackgroundWidget(
-          image: Image.network(widget.surveyDetailUiModel.largeCoverImageUrl)
-              .image,
-        ),
-        SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.all(20),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _buildQuestionToolbar(
-                  context,
-                  widget.surveyDetailUiModel.questions[_currentIndex],
-                ),
-                _buildPagedQuestions(context, pageController),
-                _buildQuestionFooter(
-                  context,
-                  widget.surveyDetailUiModel.questions[_currentIndex],
-                  pageController,
-                ),
-              ],
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildQuestionToolbar(
+              context,
+              widget.surveyDetailUiModel.questions[_currentIndex],
             ),
-          ),
+            _buildPagedQuestions(context, pageController),
+            _buildQuestionFooter(
+              context,
+              widget.surveyDetailUiModel.questions[_currentIndex],
+              pageController,
+            ),
+          ],
         ),
-      ],
+      ),
     );
   }
 
@@ -176,6 +168,8 @@ class _QuestionPagingWidgetState extends State<QuestionPagingWidget> {
         return _buildAnswerEmojiRatingWidget(question, '👍🏻');
       case DisplayType.smiley:
         return _buildAnswerSmileyWidget(question);
+      case DisplayType.textfield:
+        return _buildAnswerTextFieldWidget(question);
       default:
         return const SizedBox();
     }
@@ -198,6 +192,14 @@ class _QuestionPagingWidgetState extends State<QuestionPagingWidget> {
         // TODO: Save answer here
       },
     );
+  }
+
+  Widget _buildAnswerTextFieldWidget(QuestionUiModel question) {
+    return AnswerTextFieldWidget(
+        question: question,
+        onAnswered: (List<String> answers) {
+          // TODO: Save answer here
+        });
   }
 
   Widget _buildQuestionFooter(

--- a/lib/screens/widgets/background_widget.dart
+++ b/lib/screens/widgets/background_widget.dart
@@ -3,11 +3,13 @@ import 'package:flutter/material.dart';
 class BackgroundWidget extends StatelessWidget {
   final ImageProvider image;
   final double opacity;
+  final Widget? child;
 
   const BackgroundWidget({
     Key? key,
     required this.image,
     this.opacity = 0.35,
+    this.child,
   }) : super(key: key);
 
   @override
@@ -21,6 +23,7 @@ class BackgroundWidget extends StatelessWidget {
               Colors.black.withOpacity(opacity), BlendMode.darken),
         ),
       ),
+      child: child,
     );
   }
 }


### PR DESCRIPTION
- Closes https://github.com/nimblehq/flutter-ic-lydia-ryan/issues/35
- Closes https://github.com/nimblehq/flutter-ic-lydia-ryan/issues/36

## What happened 👀

- Created `AnswerTextFieldWidget`
- Updated `BackgroundWidget` with `child` param to fix background resizing issue 👀 

## Insight 📝

If we have `BackgroundWidget` inside `QuestionPagingWidget`, the image will resize when the keyboard is shown. To fix this, we should structure the `SurveyDetailScreen` widget like this: 
```
- Container
  - Image
  - Scaffold
    - QuestionPagingWidget
```


## Proof Of Work 📹

https://github.com/nimblehq/flutter-ic-lydia-ryan/assets/53168251/32500ecb-ed3f-4991-b729-876377a52c41
