### PR TITLE
[#23] [#24] [UI] [Integrate] Dropdown answer

### DIFF
--- a/lib/resources/dimensions.dart
+++ b/lib/resources/dimensions.dart
@@ -25,6 +25,7 @@ class Dimensions {
   static const double homeSkeletonLoadingTextBorderRadius = 10.0;
 
   static const double answerEmojiSize = 34.0;
+  static const double answerDropdownHeight = 57.0;
 
   static const double dividerWidth = 1.0;
 }

--- a/lib/screens/surveydetails/widget/answer_dropdown_widget.dart
+++ b/lib/screens/surveydetails/widget/answer_dropdown_widget.dart
@@ -8,12 +8,12 @@ const double _dropdownThreshold = 20.0;
 
 class AnswerDropdownWidget extends StatefulWidget {
   final QuestionUiModel question;
-  final Function(String) onSelected;
+  final Function(String) onSelect;
 
   const AnswerDropdownWidget({
     Key? key,
     required this.question,
-    required this.onSelected,
+    required this.onSelect,
   }) : super(key: key);
 
   @override
@@ -33,7 +33,7 @@ class _AnswerDropdownWidgetState extends State<AnswerDropdownWidget> {
     setState(() {
       _focusedIndex = index;
     });
-    widget.onSelected(widget.question.answers[index].text ?? "");
+    widget.onSelect(widget.question.answers[index].text ?? "");
   }
 
   Widget _buildListItem(BuildContext context, int index) {

--- a/lib/screens/surveydetails/widget/answer_dropdown_widget.dart
+++ b/lib/screens/surveydetails/widget/answer_dropdown_widget.dart
@@ -3,8 +3,8 @@ import 'package:lydiaryanfluttersurvey/model/ui/question_ui_model.dart';
 import 'package:lydiaryanfluttersurvey/resources/dimensions.dart';
 import 'package:scroll_snap_list/scroll_snap_list.dart';
 
-int _dropdownItemLength = 3;
-double _dropdownThreshold = 20.0;
+const int _dropdownItemLength = 3;
+const double _dropdownThreshold = 20.0;
 
 class AnswerDropdownWidget extends StatefulWidget {
   final QuestionUiModel question;

--- a/lib/screens/surveydetails/widget/answer_dropdown_widget.dart
+++ b/lib/screens/surveydetails/widget/answer_dropdown_widget.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:lydiaryanfluttersurvey/model/ui/question_ui_model.dart';
+import 'package:lydiaryanfluttersurvey/resources/dimensions.dart';
+import 'package:scroll_snap_list/scroll_snap_list.dart';
+
+int _dropdownItemLength = 3;
+double _dropdownThreshold = 20.0;
+
+class AnswerDropdownWidget extends StatefulWidget {
+  final QuestionUiModel question;
+  final Function(String) onSelected;
+
+  const AnswerDropdownWidget({
+    Key? key,
+    required this.question,
+    required this.onSelected,
+  }) : super(key: key);
+
+  @override
+  State<AnswerDropdownWidget> createState() => _AnswerDropdownWidgetState();
+}
+
+class _AnswerDropdownWidgetState extends State<AnswerDropdownWidget> {
+  int _focusedIndex = 0;
+
+  Color? _getAnswerColor(int index) =>
+      _focusedIndex == index ? Colors.white : Colors.white54;
+
+  FontWeight _getAnswerFontWeight(int index) =>
+      _focusedIndex == index ? FontWeight.bold : FontWeight.normal;
+
+  void _onItemFocus(int index) {
+    setState(() {
+      _focusedIndex = index;
+    });
+    widget.onSelected(widget.question.answers[index].text ?? "");
+  }
+
+  Widget _buildListItem(BuildContext context, int index) {
+    return Container(
+      height: Dimensions.answerDropdownHeight,
+      padding: const EdgeInsets.symmetric(
+        horizontal: Dimensions.paddingLarge,
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              vertical: Dimensions.paddingSmall,
+            ),
+            child: Container(
+              alignment: Alignment.center,
+              child: Text(widget.question.answers[index].text ?? "",
+                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        color: _getAnswerColor(index),
+                        fontWeight: _getAnswerFontWeight(index),
+                      )),
+            ),
+          ),
+          index < widget.question.answers.length - 1
+              ? const Divider(
+                  color: Colors.white,
+                  thickness: Dimensions.dividerWidth,
+                )
+              : const SizedBox(),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: SizedBox(
+        height: (_dropdownItemLength * Dimensions.answerDropdownHeight) -
+            _dropdownThreshold,
+        child: Column(
+          children: <Widget>[
+            Expanded(
+              child: ScrollSnapList(
+                scrollDirection: Axis.vertical,
+                onItemFocus: _onItemFocus,
+                itemSize: Dimensions.answerDropdownHeight,
+                itemBuilder: _buildListItem,
+                itemCount: widget.question.answers.length,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/surveydetails/widget/answer_dropdown_widget.dart
+++ b/lib/screens/surveydetails/widget/answer_dropdown_widget.dart
@@ -75,18 +75,12 @@ class _AnswerDropdownWidgetState extends State<AnswerDropdownWidget> {
       child: SizedBox(
         height: (_dropdownItemLength * Dimensions.answerDropdownHeight) -
             _dropdownThreshold,
-        child: Column(
-          children: <Widget>[
-            Expanded(
-              child: ScrollSnapList(
-                scrollDirection: Axis.vertical,
-                onItemFocus: _onItemFocus,
-                itemSize: Dimensions.answerDropdownHeight,
-                itemBuilder: _buildListItem,
-                itemCount: widget.question.answers.length,
-              ),
-            ),
-          ],
+        child: ScrollSnapList(
+          scrollDirection: Axis.vertical,
+          onItemFocus: _onItemFocus,
+          itemSize: Dimensions.answerDropdownHeight,
+          itemBuilder: _buildListItem,
+          itemCount: widget.question.answers.length,
         ),
       ),
     );

--- a/lib/screens/surveydetails/widget/question_paging_widget.dart
+++ b/lib/screens/surveydetails/widget/question_paging_widget.dart
@@ -241,7 +241,7 @@ class _QuestionPagingWidgetState extends State<QuestionPagingWidget> {
   Widget _buildAnswerDropdownWidget(QuestionUiModel question) {
     return AnswerDropdownWidget(
         question: question,
-        onSelected: (String answer) {
+        onSelect: (String answer) {
           // TODO: Save answer here
         });
   }

--- a/lib/screens/surveydetails/widget/question_paging_widget.dart
+++ b/lib/screens/surveydetails/widget/question_paging_widget.dart
@@ -7,6 +7,7 @@ import 'package:lydiaryanfluttersurvey/model/response/question_response.dart';
 import 'package:lydiaryanfluttersurvey/model/ui/question_ui_model.dart';
 import 'package:lydiaryanfluttersurvey/model/ui/survey_detail_ui_model.dart';
 import 'package:lydiaryanfluttersurvey/resources/dimensions.dart';
+import 'package:lydiaryanfluttersurvey/screens/surveydetails/widget/answer_dropdown_widget.dart';
 import 'package:lydiaryanfluttersurvey/screens/surveydetails/widget/answer_intro_widget.dart';
 import 'package:lydiaryanfluttersurvey/screens/surveydetails/widget/answer_multi_choice_widget.dart';
 import 'package:lydiaryanfluttersurvey/screens/surveydetails/widget/answer_nps_widget.dart';
@@ -170,6 +171,8 @@ class _QuestionPagingWidgetState extends State<QuestionPagingWidget> {
         return _buildAnswerTextFieldWidget(question);
       case DisplayType.choice:
         return _buildAnswerMultiChoiceWidget(question);
+      case DisplayType.dropdown:
+        return _buildAnswerDropdownWidget(question);
       default:
         return const SizedBox();
     }
@@ -231,6 +234,14 @@ class _QuestionPagingWidgetState extends State<QuestionPagingWidget> {
     return AnswerMultiChoiceWidget(
         question: question,
         onCheck: (List<String> answerIds) {
+          // TODO: Save answer here
+        });
+  }
+
+  Widget _buildAnswerDropdownWidget(QuestionUiModel question) {
+    return AnswerDropdownWidget(
+        question: question,
+        onSelected: (String answer) {
           // TODO: Save answer here
         });
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -804,6 +804,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
+  scroll_snap_list:
+    dependency: "direct main"
+    description:
+      name: scroll_snap_list
+      sha256: "8009ad9030f680b93f3107b29b1ea31284d867aa4972868d2970c6d61fe9e59f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   pull_to_refresh: ^2.0.0
   retrofit: ^3.0.1+1
   rxdart: ^0.27.7
+  scroll_snap_list: ^0.9.1
   shared_preferences: ^2.1.0
   shimmer: ^2.0.0
   smooth_page_indicator: ^1.1.0


### PR DESCRIPTION
- Closes https://github.com/nimblehq/flutter-ic-lydia-ryan/issues/23
- Closes https://github.com/nimblehq/flutter-ic-lydia-ryan/issues/24

## What happened 👀

Implemented UI and integration for dropdown answer.

## Insight 📝

- Used [scroll_snap_list: ^0.9.1](https://pub.dev/packages/scroll_snap_list) library to make it snap the focused text at the center.
- As I ran it on the simulator, I could not test the swipe gesture. By the way, this library support `focusOnItemTap` so we can select it by tapping on the item.

## Proof Of Work 📹


https://github.com/nimblehq/flutter-ic-lydia-ryan/assets/12026942/61df882b-e1db-459e-adfe-86fe46c6e6ec


