### PR TITLE
[#26] Single selection 

### DIFF
--- a/lib/model/response/question_response.dart
+++ b/lib/model/response/question_response.dart
@@ -19,17 +19,29 @@ enum DisplayType {
   unknown
 }
 
+enum PickType {
+  @JsonValue('none')
+  none,
+  @JsonValue('one')
+  single,
+  @JsonValue('any')
+  multiple,
+  unknown
+}
+
 @JsonSerializable()
 class QuestionResponse {
   final String? id;
   final String? text;
   final DisplayType? displayType;
+  final PickType? pick;
   final List<AnswerResponse>? answers;
 
   QuestionResponse(
     this.id,
     this.text,
     this.displayType,
+    this.pick,
     this.answers,
   );
 

--- a/lib/model/ui/question_ui_model.dart
+++ b/lib/model/ui/question_ui_model.dart
@@ -6,12 +6,14 @@ class QuestionUiModel {
   final String id;
   final String text;
   final DisplayType displayType;
+  final PickType pickType;
   final List<AnswerUiModel> answers;
 
   QuestionUiModel({
     required this.id,
     required this.text,
     required this.displayType,
+    required this.pickType,
     required this.answers,
   });
 
@@ -20,6 +22,7 @@ class QuestionUiModel {
       id: e.id ?? '',
       text: e.text ?? '',
       displayType: e.displayType ?? DisplayType.unknown,
+      pickType: e.pick ?? PickType.unknown,
       answers:
           e.answers?.map((e) => AnswerUiModel.fromAnswerResponse(e)).toList() ??
               [],

--- a/lib/screens/surveydetails/widget/answer_multi_choice_widget.dart
+++ b/lib/screens/surveydetails/widget/answer_multi_choice_widget.dart
@@ -74,9 +74,9 @@ class _AnswerMultiChoiceWidgetState extends State<AnswerMultiChoiceWidget> {
                       children: [
                         Text(widget.question.answers[index].text ?? "",
                             style:
-                            Theme.of(context).textTheme.bodyLarge?.copyWith(
-                              color: _getAnswerColor(index),
-                            )),
+                                Theme.of(context).textTheme.bodyLarge?.copyWith(
+                                      color: _getAnswerColor(index),
+                                    )),
                         Transform.scale(
                           scale: 1.3,
                           child: Checkbox(
@@ -86,7 +86,7 @@ class _AnswerMultiChoiceWidgetState extends State<AnswerMultiChoiceWidget> {
                               widget.question.answers[index].id,
                             ),
                             fillColor: MaterialStateColor.resolveWith(
-                                    (states) => Colors.white),
+                                (states) => Colors.white),
                             checkColor: Colors.black,
                             shape: const CircleBorder(),
                             side: const BorderSide(
@@ -98,9 +98,9 @@ class _AnswerMultiChoiceWidgetState extends State<AnswerMultiChoiceWidget> {
                     ),
                     index < widget.question.answers.length - 1
                         ? const Divider(
-                      color: Colors.white,
-                      thickness: 0.5,
-                    )
+                            color: Colors.white,
+                            thickness: Dimensions.dividerWidth,
+                          )
                         : const SizedBox(),
                   ],
                 ),

--- a/lib/screens/surveydetails/widget/answer_multi_choice_widget.dart
+++ b/lib/screens/surveydetails/widget/answer_multi_choice_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lydiaryanfluttersurvey/model/response/question_response.dart';
 import 'package:lydiaryanfluttersurvey/model/ui/question_ui_model.dart';
 import 'package:lydiaryanfluttersurvey/resources/dimensions.dart';
 
@@ -26,6 +27,9 @@ class _AnswerMultiChoiceWidgetState extends State<AnswerMultiChoiceWidget> {
   ) {
     setState(() {
       if (isChecked == true) {
+        if (widget.question.pickType == PickType.single) {
+          _checkedAnswerIds.clear();
+        }
         _checkedAnswerIds.add(answerId);
       } else {
         _checkedAnswerIds.remove(answerId);
@@ -47,6 +51,10 @@ class _AnswerMultiChoiceWidgetState extends State<AnswerMultiChoiceWidget> {
 
   @override
   Widget build(BuildContext context) {
+    if (widget.question.pickType == PickType.unknown) {
+      return const SizedBox();
+    }
+
     return Center(
       child: ListView(
         shrinkWrap: true,
@@ -66,9 +74,9 @@ class _AnswerMultiChoiceWidgetState extends State<AnswerMultiChoiceWidget> {
                       children: [
                         Text(widget.question.answers[index].text ?? "",
                             style:
-                                Theme.of(context).textTheme.bodyLarge?.copyWith(
-                                      color: _getAnswerColor(index),
-                                    )),
+                            Theme.of(context).textTheme.bodyLarge?.copyWith(
+                              color: _getAnswerColor(index),
+                            )),
                         Transform.scale(
                           scale: 1.3,
                           child: Checkbox(
@@ -78,7 +86,7 @@ class _AnswerMultiChoiceWidgetState extends State<AnswerMultiChoiceWidget> {
                               widget.question.answers[index].id,
                             ),
                             fillColor: MaterialStateColor.resolveWith(
-                                (states) => Colors.white),
+                                    (states) => Colors.white),
                             checkColor: Colors.black,
                             shape: const CircleBorder(),
                             side: const BorderSide(
@@ -90,9 +98,9 @@ class _AnswerMultiChoiceWidgetState extends State<AnswerMultiChoiceWidget> {
                     ),
                     index < widget.question.answers.length - 1
                         ? const Divider(
-                            color: Colors.white,
-                            thickness: 0.5,
-                          )
+                      color: Colors.white,
+                      thickness: 0.5,
+                    )
                         : const SizedBox(),
                   ],
                 ),


### PR DESCRIPTION
- Closes https://github.com/nimblehq/flutter-ic-lydia-ryan/issues/26

## What happened 👀

- Added `PickType` to handle `pick` property from the response.
- Handled single selection; when `pick = "one"`

## Insight 📝

N/A

## Proof Of Work 📹

Single selection case:

https://github.com/nimblehq/flutter-ic-lydia-ryan/assets/12026942/91f698cb-c43b-4cf3-a2a8-675ea4b23636

Multiple selection case:

https://github.com/nimblehq/flutter-ic-lydia-ryan/assets/12026942/1487d5a4-c8da-47a7-9398-4c4b501e47e7


