### PR TITLE
[#97] [Backend] As a user, I can fetch surveys with pagination

### DIFF
--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -5,7 +5,10 @@ import 'package:lydiaryanfluttersurvey/model/response/survey_detail_response.dar
 import 'package:lydiaryanfluttersurvey/model/response/surveys_response.dart';
 
 abstract class SurveyRepository {
-  Future<SurveysResponse> getSurveys();
+  Future<SurveysResponse> getSurveys({
+    required int pageNumber,
+    required int pageSize,
+  });
 
   Future<SurveyDetailResponse> getSurveyDetail(String surveyId);
 }
@@ -17,9 +20,12 @@ class SurveyRepositoryImpl implements SurveyRepository {
   SurveyRepositoryImpl(this._surveyService);
 
   @override
-  Future<SurveysResponse> getSurveys() {
+  Future<SurveysResponse> getSurveys({
+    required int pageNumber,
+    required int pageSize,
+  }) {
     try {
-      return _surveyService.getSurveys();
+      return _surveyService.getSurveys(pageNumber, pageSize);
     } catch (e) {
       return Future.error(NetworkExceptions.fromDioException(e));
     }

--- a/lib/api/service/survey_service.dart
+++ b/lib/api/service/survey_service.dart
@@ -10,7 +10,10 @@ abstract class SurveyService {
   factory SurveyService(Dio dio, {String baseUrl}) = _SurveyService;
 
   @GET('/api/v1/surveys')
-  Future<SurveysResponse> getSurveys();
+  Future<SurveysResponse> getSurveys(
+    @Query('page[number]') int pageNumber,
+    @Query('page[size]') int pageSize,
+  );
 
   @GET('api/v1/surveys/{surveyId}')
   Future<SurveyDetailResponse> getSurveyDetail(

--- a/lib/model/response/surveys_meta_response.dart
+++ b/lib/model/response/surveys_meta_response.dart
@@ -1,0 +1,22 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:lydiaryanfluttersurvey/model/response/converter/response_converter.dart';
+
+part 'surveys_meta_response.g.dart';
+
+@JsonSerializable()
+class SurveysMetaResponse {
+  final int? page;
+  final int? pages;
+  final int? pageSize;
+  final int? records;
+
+  SurveysMetaResponse(
+    this.page,
+    this.pages,
+    this.pageSize,
+    this.records,
+  );
+
+  factory SurveysMetaResponse.fromJson(Map<String, dynamic> json) =>
+      _$SurveysMetaResponseFromJson(fromJsonApi(json));
+}

--- a/lib/model/response/surveys_response.dart
+++ b/lib/model/response/surveys_response.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:lydiaryanfluttersurvey/model/response/converter/response_converter.dart';
 import 'package:lydiaryanfluttersurvey/model/response/survey_response.dart';
+import 'package:lydiaryanfluttersurvey/model/response/surveys_meta_response.dart';
 
 part 'surveys_response.g.dart';
 
@@ -8,9 +9,12 @@ part 'surveys_response.g.dart';
 class SurveysResponse {
   @JsonKey(name: 'data')
   final List<SurveyResponse> surveysResponse;
+  @JsonKey(name: 'meta')
+  final SurveysMetaResponse? metaResponse;
 
   SurveysResponse(
     this.surveysResponse,
+    this.metaResponse,
   );
 
   factory SurveysResponse.fromJson(Map<String, dynamic> json) =>

--- a/lib/screens/home/home_view_model.dart
+++ b/lib/screens/home/home_view_model.dart
@@ -6,20 +6,26 @@ import 'package:lydiaryanfluttersurvey/usecases/base/base_use_case.dart';
 import 'package:lydiaryanfluttersurvey/usecases/get_surveys_use_case.dart';
 import 'package:rxdart/subjects.dart';
 
+const _pageSize = 10;
+
 class HomeViewModel extends StateNotifier<HomeState> {
   final GetSurveysUseCase _getSurveysUseCase;
 
   final BehaviorSubject<List<SurveyUiModel>> _surveys = BehaviorSubject();
   Stream<List<SurveyUiModel>> get surveys => _surveys.stream;
 
+  // TODO: Update this value in integrate ticket
+  final int _currentPage = 1;
+
   HomeViewModel(this._getSurveysUseCase) : super(const HomeState.init());
 
   Future<void> getSurveys() async {
-    final result = await _getSurveysUseCase.call();
+    final getSurveysInput = GetSurveysInput(_currentPage, _pageSize);
+    final result = await _getSurveysUseCase.call(getSurveysInput);
 
     if (result is Success<SurveysResponse>) {
       final surveys = result.value.surveysResponse
-          .map((e) => SurveyUiModel.fromSurveyResponse(e))
+          .map((response) => SurveyUiModel.fromSurveyResponse(response))
           .toList();
       _surveys.add(surveys);
       state = const HomeState.success();

--- a/lib/usecases/get_surveys_use_case.dart
+++ b/lib/usecases/get_surveys_use_case.dart
@@ -4,18 +4,28 @@ import 'package:lydiaryanfluttersurvey/model/response/surveys_response.dart';
 import 'package:lydiaryanfluttersurvey/usecases/base/base_use_case.dart';
 
 @Injectable()
-class GetSurveysUseCase extends NoParamsUseCase<SurveysResponse> {
+class GetSurveysUseCase extends UseCase<SurveysResponse, GetSurveysInput> {
   final SurveyRepository _surveyRepository;
 
   GetSurveysUseCase(this._surveyRepository);
 
   @override
-  Future<Result<SurveysResponse>> call() {
+  Future<Result<SurveysResponse>> call(GetSurveysInput params) {
     return _surveyRepository
-        .getSurveys()
+        .getSurveys(
+          pageNumber: params.pageNumber,
+          pageSize: params.pageSize,
+        )
         // ignore: unnecessary_cast
         .then((value) => Success(value) as Result<SurveysResponse>)
         .onError<Exception>(
             (error, stackTrace) => Failed(UseCaseException(error)));
   }
+}
+
+class GetSurveysInput {
+  final int pageNumber;
+  final int pageSize;
+
+  GetSurveysInput(this.pageNumber, this.pageSize);
 }

--- a/test/usecases/get_surveys_use_case_test.dart
+++ b/test/usecases/get_surveys_use_case_test.dart
@@ -17,20 +17,20 @@ void main() {
     });
 
     test('When getSurveys is successful, it returns Success result', () async {
-      final surveysResponse = SurveysResponse([]);
-      when(mockSurveyRepository.getSurveys())
+      final surveysResponse = SurveysResponse([], null);
+      when(mockSurveyRepository.getSurveys(pageNumber: 1, pageSize: 1))
           .thenAnswer((_) async => surveysResponse);
 
-      final result = await useCase.call();
+      final result = await useCase.call(GetSurveysInput(1, 1));
 
       expect(result, isA<Success<SurveysResponse>>());
     });
 
     test('When getSurveys is unsuccessful, it returns Failed result', () async {
-      when(mockSurveyRepository.getSurveys())
+      when(mockSurveyRepository.getSurveys(pageNumber: 1, pageSize: 1))
           .thenAnswer((_) => Future.error(UseCaseException(Exception(''))));
 
-      final result = await useCase.call();
+      final result = await useCase.call(GetSurveysInput(1, 1));
 
       expect(result, isA<Failed<SurveysResponse>>());
     });

--- a/test/viewmodels/home_view_model_test.dart
+++ b/test/viewmodels/home_view_model_test.dart
@@ -20,9 +20,9 @@ void main() {
 
     test('When getSurveys is successful, it emits success state', () async {
       final viewModelStream = viewModel.stream;
-      final surveysResponse = SurveysResponse([]);
+      final surveysResponse = SurveysResponse([], null);
 
-      when(mockGetUserUseCase.call())
+      when(mockGetUserUseCase.call(any))
           .thenAnswer((_) async => Success(surveysResponse));
 
       expect(viewModelStream, emits(const HomeState.success()));
@@ -36,7 +36,7 @@ void main() {
       final actualException = Exception();
 
       when(mockException.actualException).thenReturn(actualException);
-      when(mockGetUserUseCase.call())
+      when(mockGetUserUseCase.call(any))
           .thenAnswer((_) async => Failed(mockException));
 
       expect(


### PR DESCRIPTION
- Closes https://github.com/nimblehq/flutter-ic-lydia-ryan/issues/97

## What happened 👀

- Added `page[number]` and `page[size]` arguments to fetch survey request
- Added `SurveyMetaResponse` to fetch `SurveysResponse`

## Insight 📝

- We can use the returned data in `SurveyMetaResponse` to set the page values for the next request 🙏🏻 

## Proof Of Work 📹

```
I/flutter (29138): *** Request ***
I/flutter (29138): uri: https://survey-api.nimblehq.co/api/v1/surveys?page%5Bnumber%5D=1&page%5Bsize%5D=10
I/flutter (29138): method: GET
I/flutter (29138): responseType: ResponseType.json
I/flutter (29138): followRedirects: true
I/flutter (29138): connectTimeout: 3000
I/flutter (29138): sendTimeout: 0
I/flutter (29138): receiveTimeout: 5000
I/flutter (29138): receiveDataWhenStatusError: true
I/flutter (29138): extra: {}
I/flutter (29138): headers:
I/flutter (29138):  Authorization: Bearer miqWgb2LwJKeE1oo4TQ_2QExBb9idUcu0KU65YMQF3I
I/flutter (29138): data:
I/flutter (29138): {}
I/flutter (29138): 
I/flutter (29138): *** Response ***
I/flutter (29138): uri: https://survey-api.nimblehq.co/api/v1/surveys?page%5Bnumber%5D=1&page%5Bsize%5D=10
I/flutter (29138): statusCode: 200
```
