### PR TITLE
[#112] Fix text width to limit to 60 percent of screen

### DIFF
--- a/lib/screens/surveydetails/widget/answer_multi_choice_widget.dart
+++ b/lib/screens/surveydetails/widget/answer_multi_choice_widget.dart
@@ -72,11 +72,16 @@ class _AnswerMultiChoiceWidgetState extends State<AnswerMultiChoiceWidget> {
                       crossAxisAlignment: CrossAxisAlignment.center,
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        Text(widget.question.answers[index].text ?? "",
-                            style:
-                                Theme.of(context).textTheme.bodyLarge?.copyWith(
-                                      color: _getAnswerColor(index),
-                                    )),
+                        SizedBox(
+                          width: MediaQuery.of(context).size.width * 0.6,
+                          child: Text(widget.question.answers[index].text ?? "",
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodyLarge
+                                  ?.copyWith(
+                                    color: _getAnswerColor(index),
+                                  )),
+                        ),
                         Transform.scale(
                           scale: 1.3,
                           child: Checkbox(


### PR DESCRIPTION
- Closes https://github.com/nimblehq/flutter-ic-lydia-ryan/issues/112

## What happened 👀

- Assign max width to the answer text to be 60 percent of screen

## Insight 📝

N/A

## Proof Of Work 📹

<img src=https://github.com/nimblehq/flutter-ic-lydia-ryan/assets/12026942/ba6c6ca2-db75-4500-b6c0-8ee4074cb302 width=400/>
